### PR TITLE
Fixes to the generation of the Maven pom.xml files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,6 +200,50 @@ gradle.taskGraph.whenReady { taskGraph ->
   }
 }
 
+def mavenPom = {
+  name 'XML Calabash MarkLogic XCC Steps'
+  packaging 'jar'
+  description 'XML Calabash extension steps to communicate with MarkLogic server'
+  url 'https://github.com/ndw/xmlcalabash1-xcc'
+
+  scm {
+    url 'scm:git@github.com:ndw/xmlcalabash1-xcc.git'
+    connection 'scm:git@github.com:ndw/xmlcalabash1-xcc.git'
+    developerConnection 'scm:git@github.com:ndw/xmlcalabash1-xcc.git'
+  }
+
+  licenses {
+    license {
+      name 'The Apache Software License, Version 2.0'
+      url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+      distribution 'repo'
+    }
+  }
+
+  developers {
+    developer {
+      id 'ndw'
+      name 'Norman Walsh'
+    }
+  }
+
+  repositories {
+    repository {
+      id 'marklogic'
+      url 'http://developer.marklogic.com/maven2'
+    }
+  }
+
+}
+
+install {
+  repositories {
+    mavenInstaller {
+      pom.project(mavenPom)
+    }
+  }
+}
+
 uploadArchives {
   repositories {
     mavenDeployer {
@@ -214,41 +258,7 @@ uploadArchives {
         authentication(userName: sonatypeUsername, password: sonatypePassword)
       }
 
-      pom.project {
-        name 'XML Calabash MarkLogic XCC Steps'
-        packaging 'jar'
-        description 'XML Calabash extension steps to communicate with MarkLogic server'
-        url 'https://github.com/ndw/xmlcalabash1-xcc'
-
-        scm {
-          url 'scm:git@github.com:ndw/xmlcalabash1-xcc.git'
-          connection 'scm:git@github.com:ndw/xmlcalabash1-xcc.git'
-          developerConnection 'scm:git@github.com:ndw/xmlcalabash1-xcc.git'
-        }
-
-        licenses {
-          license {
-            name 'The Apache Software License, Version 2.0'
-            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-            distribution 'repo'
-          }
-        }
-
-        developers {
-          developer {
-            id 'ndw'
-            name 'Norman Walsh'
-          }
-        }
-
-        repositories {
-          repository {
-            id 'marklogic'
-            url 'http://developer.marklogic.com/maven2'
-          }
-        }
-
-      }
+      pom.project(mavenPom)
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -240,6 +240,14 @@ uploadArchives {
             name 'Norman Walsh'
           }
         }
+
+        repositories {
+          repository {
+            id 'marklogic'
+            url 'http://developer.marklogic.com/maven2'
+          }
+        }
+
       }
     }
   }


### PR DESCRIPTION
The published Maven pom.xml file for version `1.1.3` is missing a required repository to be able to use the artifact with a Maven project.

i.e. https://repo1.maven.org/maven2/com/xmlcalabash/xmlcalabash1-xcc/1.1.3/xmlcalabash1-xcc-1.1.3.pom is missing the section:

``` xml
<repositories>
    <repository>
        <id>marklogic</id>
        <url>http://developer.marklogic.com/maven2</url>
    </repository>
</repositories>
```

which is required to resolve it's dependency on: `com.marklogic:marklogic-xcc:7.0.5`.

This PR ensures that:
1. The repository is added to the pom.xml before publishing.
2. The `install` task also generates the correct pom.xml.
